### PR TITLE
Simplify newline handling and make output more consistent

### DIFF
--- a/console-reporter.js
+++ b/console-reporter.js
@@ -67,54 +67,51 @@ function ConsoleReporter() {
 		executableSpecCount = 0;
 		failureCount = 0;
 		if (options && options.order && options.order.random) {
-			print('Randomized with seed ' + options.order.seed);
-			printNewline();
+			printLine('Randomized with seed ' + options.order.seed);
 		}
-		print('Started');
-		printNewline();
+		printLine('Started');
 		timer.start();
 	};
 
 	this.jasmineDone = function (result) {
-		printNewline();
-		printNewline();
+		printNewline(); // line break after last dot
+		printNewline(); // empty line
+
 		if (failedSpecs.length > 0) {
-			print('Failures:');
-		}
-		for (var i = 0; i < failedSpecs.length; i++) {
-			specFailureDetails(failedSpecs[i], i + 1);
+			printLine('Failures:');
+			printNewline();
+			for (var i = 0; i < failedSpecs.length; i++) {
+				specFailureDetails(failedSpecs[i], i + 1);
+			}
+			printNewline();
 		}
 
 		if (pendingSpecs.length > 0) {
-			print("Pending:");
-		}
-		for (i = 0; i < pendingSpecs.length; i++) {
-			pendingSpecDetails(pendingSpecs[i], i + 1);
+			printLine("Pending:");
+			printNewline();
+			for (i = 0; i < pendingSpecs.length; i++) {
+				pendingSpecDetails(pendingSpecs[i], i + 1);
+			}
+			printNewline();
 		}
 
 		if (specCount > 0) {
-			printNewline();
-
 			if (executableSpecCount !== specCount) {
-				print('Ran ' + executableSpecCount + ' of ' + specCount + plural(' spec', specCount));
-				printNewline();
+				printLine('Ran ' + executableSpecCount + ' of ' + specCount + plural(' spec', specCount));
 			}
+
 			var specCounts = executableSpecCount + ' ' + plural('spec', executableSpecCount) + ', ' +
 				failureCount + ' ' + plural('failure', failureCount);
-
 			if (pendingSpecs.length) {
 				specCounts += ', ' + pendingSpecs.length + ' pending ' + plural('spec', pendingSpecs.length);
 			}
-
-			print(specCounts);
+			printLine(specCounts);
 		} else {
-			print('No specs found');
+			printLine('No specs found');
 		}
 
-		printNewline();
 		var seconds = timer.elapsed() / 1000;
-		print('Finished in ' + seconds + ' ' + plural('second', seconds));
-		printNewline();
+		printLine('Finished in ' + seconds + ' ' + plural('second', seconds));
 
 		for (i = 0; i < failedSuites.length; i++) {
 			suiteFailureDetails(failedSuites[i]);
@@ -125,8 +122,7 @@ function ConsoleReporter() {
 		}
 
 		if (result && result.order && result.order.random) {
-			print('Randomized with seed ' + result.order.seed);
-			printNewline();
+			printLine('Randomized with seed ' + result.order.seed);
 		}
 
 		onComplete(failureCount === 0);
@@ -166,6 +162,11 @@ function ConsoleReporter() {
 	return this;
 
 	function printNewline() {
+		print('\n');
+	}
+
+	function printLine(str) {
+		print(str);
 		print('\n');
 	}
 
@@ -214,7 +215,6 @@ function ConsoleReporter() {
 	}
 
 	function specFailureDetails(result, failedSpecNumber) {
-		printNewline();
 		print(failedSpecNumber + ') ');
 		print(titleFilter(result.fullName));
 
@@ -235,18 +235,12 @@ function ConsoleReporter() {
 
 	function suiteFailureDetails(result) {
 		for (var i = 0; i < result.failedExpectations.length; i++) {
-			printNewline();
-			print(colored('red', 'An error was thrown in an afterAll'));
-			printNewline();
-			print(colored('red', 'AfterAll ' + result.failedExpectations[i].message));
-
+			printLine(colored('red', 'An error was thrown in an afterAll'));
+			printLine(colored('red', 'AfterAll ' + result.failedExpectations[i].message));
 		}
-		printNewline();
 	}
 
 	function pendingSpecDetails(result, pendingSpecNumber) {
-		printNewline();
-		printNewline();
 		print(pendingSpecNumber + ') ');
 		print(result.fullName);
 		printNewline();


### PR DESCRIPTION
Heyho! Thanks for providing this library.

This adds a `printLine` helper to print a full line including `\n`. The whitespacing before was a bit confusing and was improved.

Before

```
Randomized with seed 04221
Started
......................F.**F..

Failures:
1) Encoding UTF8 encoding decodes Supplementary Multilingual Plane strings
  Message:
    Expected '𑍊' to equal '𐍊'.
  Stack:
        at UserContext.it (/home/me/myproject/src/encoding.spec.ts:162:74)

2) Encoding UTF8 encoding encodes Basic Multilingual Plane strings
  Message:
    Expected object not to have properties
        2: 32
  Stack:
        at UserContext.it (/home/me/myproject/src/encoding.spec.ts:136:36)
Pending:

1) Encoding UTF8 encoding encodes Supplementary Multilingual Plane strings
  Not yet done


2) Encoding UTF8 encoding decodes Basic Multilingual Plane strings
  oh nooo

29 specs, 2 failures, 2 pending specs
Finished in 0.087 seconds

Randomized with seed 04221

```

After

```
Randomized with seed 01223
Started
....FF.*.*...................

Failures:

1) Encoding UTF8 encoding decodes Supplementary Multilingual Plane strings
  Message:
    Expected '𑍊' to equal '𐍊'.
  Stack:
        at UserContext.it (/home/me/myproject/src/encoding.spec.ts:162:74)
2) Encoding UTF8 encoding encodes Basic Multilingual Plane strings
  Message:
    Expected object not to have properties
        2: 32
  Stack:
        at UserContext.it (/home/me/myproject/src/encoding.spec.ts:136:36)

Pending:

1) Encoding UTF8 encoding decodes Basic Multilingual Plane strings
  oh nooo
2) Encoding UTF8 encoding encodes Supplementary Multilingual Plane strings
  Not yet done

29 specs, 2 failures, 2 pending specs
Finished in 0.09 seconds
Randomized with seed 01223
```